### PR TITLE
feat: add meta/info client; add crate version to user-agent

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,13 @@
 pub mod api;
 pub mod auth;
 pub mod error;
+pub mod meta;
 
 use anyhow::Result;
 use std::env;
 use url::Url;
 
+const VERSION: Option<&str> = option_env!("CARGO_PKG_VERSION");
 const DEFAULT_USER_AGENT: &str = "flipt-rust";
 
 #[derive(Debug)]
@@ -28,7 +30,7 @@ impl Config {
         Self {
             endpoint,
             auth_scheme,
-            user_agent: DEFAULT_USER_AGENT.into(),
+            user_agent: format!("{}/{}", DEFAULT_USER_AGENT, VERSION.unwrap_or("unknown")),
         }
     }
 
@@ -38,13 +40,23 @@ impl Config {
     }
 }
 
+impl Default for Config {
+    fn default() -> Self {
+        Self::new(
+            Url::parse("http://localhost:8080").unwrap(),
+            AuthScheme::None,
+        )
+    }
+}
+
 fn endpoint_from_env() -> Result<Url, url::ParseError> {
     let endpoint = env::var("FLIPT_ENDPOINT").unwrap_or_default();
     Url::parse(&endpoint)
 }
 
 fn user_agent_from_env() -> String {
-    env::var("FLIPT_USER_AGENT").unwrap_or_else(|_| DEFAULT_USER_AGENT.into())
+    env::var("FLIPT_USER_AGENT")
+        .unwrap_or_else(|_| format!("{}/{}", DEFAULT_USER_AGENT, VERSION.unwrap_or("unknown")))
 }
 
 fn auth_scheme_from_env() -> AuthScheme {

--- a/src/meta/info.rs
+++ b/src/meta/info.rs
@@ -10,6 +10,11 @@ impl<'client> InfoClient<'client> {
     }
 
     pub async fn get(&self) -> Result<String> {
-        self.client.get("/meta/info", None::<&()>).await
+        let result: Result<serde_json::Value> = self.client.get("/meta/info", None::<&()>).await;
+
+        match result {
+            Ok(value) => Ok(value.to_string()),
+            Err(e) => Err(e),
+        }
     }
 }

--- a/src/meta/info.rs
+++ b/src/meta/info.rs
@@ -1,0 +1,15 @@
+use crate::meta::{MetaClient, Result};
+
+pub struct InfoClient<'client> {
+    client: &'client MetaClient,
+}
+
+impl<'client> InfoClient<'client> {
+    pub fn new(client: &'client MetaClient) -> Self {
+        Self { client }
+    }
+
+    pub async fn get(&self) -> Result<String> {
+        self.client.get("/meta/info", None::<&()>).await
+    }
+}

--- a/src/meta/mod.rs
+++ b/src/meta/mod.rs
@@ -1,0 +1,70 @@
+pub mod info;
+
+use reqwest::Url;
+
+use crate::{
+    error::{Error, UpstreamError},
+    AuthScheme, Config,
+};
+
+pub type Result<T> = anyhow::Result<T>;
+
+#[derive(Debug)]
+pub struct MetaClient {
+    client: reqwest::Client,
+    auth_scheme: AuthScheme,
+    endpoint: Url,
+}
+
+impl MetaClient {
+    pub fn new(config: Config) -> Result<Self> {
+        let client = reqwest::Client::builder()
+            .user_agent(config.user_agent)
+            .build()?;
+
+        Ok(Self {
+            client,
+            auth_scheme: config.auth_scheme,
+            endpoint: config.endpoint,
+        })
+    }
+    pub fn info(&self) -> info::InfoClient {
+        info::InfoClient::new(self)
+    }
+
+    pub(crate) async fn get<P, R>(&self, path: &str, params: Option<&P>) -> Result<R>
+    where
+        P: serde::Serialize,
+        R: serde::de::DeserializeOwned,
+    {
+        let url = self.build_url(path)?;
+        let mut request = self.client.get(url);
+        if let Some(params) = params {
+            request = request.query(params);
+        }
+        let resp = self.send(request).await?;
+        deserialize(resp).await
+    }
+
+    async fn send(&self, mut request: reqwest::RequestBuilder) -> Result<reqwest::Response> {
+        match self.auth_scheme {
+            AuthScheme::None => {}
+            AuthScheme::BearerToken(ref token) => {
+                request = request.bearer_auth(token);
+            }
+        }
+        Ok(request.send().await?)
+    }
+
+    fn build_url(&self, path: &str) -> Result<Url> {
+        Ok(self.endpoint.join(path)?)
+    }
+}
+
+pub async fn deserialize<T: serde::de::DeserializeOwned>(resp: reqwest::Response) -> Result<T> {
+    if resp.status().is_success() {
+        return Ok(resp.json::<T>().await?);
+    }
+    let parsed_err = resp.json::<UpstreamError>().await?;
+    Err(anyhow::Error::new(Error::Upstream(parsed_err)))
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,18 +1,21 @@
-use flipt::api::{
-    constraint::{
-        ComparisonType, Constraint, ConstraintCreateRequest, ConstraintDeleteRequest, Operator,
-    },
-    distribution::DistributionCreateRequest,
-    evaluation::{EvaluateRequest, Reason},
-    flag::{FlagCreateRequest, FlagDeleteRequest},
-    namespace::{NamespaceCreateRequest, NamespaceDeleteRequest},
-    rule::{Rule, RuleCreateRequest, RuleDeleteRequest},
-    segment::{Match, SegmentCreateRequest, SegmentDeleteRequest},
-    variant::{Variant, VariantCreateRequest},
-    ApiClient,
-};
 use flipt::auth::{token::TokenCreateRequest, token::TokenListRequest, AuthClient};
 use flipt::Config;
+use flipt::{
+    api::{
+        constraint::{
+            ComparisonType, Constraint, ConstraintCreateRequest, ConstraintDeleteRequest, Operator,
+        },
+        distribution::DistributionCreateRequest,
+        evaluation::{EvaluateRequest, Reason},
+        flag::{FlagCreateRequest, FlagDeleteRequest},
+        namespace::{NamespaceCreateRequest, NamespaceDeleteRequest},
+        rule::{Rule, RuleCreateRequest, RuleDeleteRequest},
+        segment::{Match, SegmentCreateRequest, SegmentDeleteRequest},
+        variant::{Variant, VariantCreateRequest},
+        ApiClient,
+    },
+    meta::MetaClient,
+};
 
 #[tokio::test]
 #[cfg_attr(not(feature = "flipt_integration"), ignore)]
@@ -288,4 +291,14 @@ async fn integration_auth() {
 
     let me = client.me().await.expect("me");
     assert_ne!(me.id, "");
+}
+
+#[tokio::test]
+#[cfg_attr(not(feature = "flipt_integration"), ignore)]
+async fn integration_meta() {
+    let config = Config::new_from_env().expect("config");
+    let client = MetaClient::new(config).expect("build client");
+
+    let info = client.info().get().await.expect("info");
+    assert_ne!(info.is_empty(), true);
 }


### PR DESCRIPTION
- adds metadata client to get `/meta/info` (can be used to ensure Flipt server is running/accessible)
- adds the version of this crate to the user agent string (ie: `flipt-rust/0.5.0`)
- implements `Default` for `Config` (`Config::default()`)