### PR TITLE
feat: impl Clone for Config struct

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@ use url::Url;
 const VERSION: Option<&str> = option_env!("CARGO_PKG_VERSION");
 const DEFAULT_USER_AGENT: &str = "flipt-rust";
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Config {
     endpoint: Url,
     auth_scheme: AuthScheme,


### PR DESCRIPTION
I want to be able to clone a config object to use for multiple clients, ie:

```rust
    let flipt_config = flipt::Config::default();

    flipt::meta::MetaClient::new(flipt_config)?
        .info()
        .get()
        .await?;

    let flipt_client = flipt::api::ApiClient::new(flipt_config)?;
```

Since the clients take ownership of the `config` argument, the only (easy) way I can see to do this is to implement `Clone` for `Config` and then `.clone()` it for each client I want to use.

Im not sure if this is the 'best' or idiomatic way to do this though.. so feel free to push back @brettbuddin 