### PR TITLE
chore: use our GH app to create the release PR

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -8,7 +8,15 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate token
+        id: generate_token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.FLIPT_RELEASE_BOT_APP_ID }}
+          private_key: ${{ secrets.FLIPT_RELEASE_BOT_APP_PEM }}
+          installation_id: ${{ secrets.FLIPT_RELEASE_BOT_INSTALLATION_ID }}
+
       - uses: google-github-actions/release-please-action@v3
         with:
-          token: ${{ secrets.RELEASE_TOKEN }}
+          token: ${{ steps.generate_token.outputs.token }}
           command: manifest


### PR DESCRIPTION
Will allow me to approve the PR since I will no longer be the created, plus it's cleaner IMO. Would like to deprecate the `RELEASE_TOKEN` secret as its long-lived