### PR TITLE
fix: use rustls instead of default tls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ flipt_integration = []
 [dependencies]
 anyhow = "1.0.66"
 chrono = { version = "0.4.23", default-features = false, features = ["serde", "clock"] }
-reqwest = { version = "0.11.13", default-features = false, features = ["json", "default-tls"] }
+reqwest = { version = "0.11.13", default-features = false, features = ["json", "rustls-tls"] }
 serde = { version = "1.0.147", features = ["derive"] }
 serde_json = "1.0.89"
 url = "2.3.1"


### PR DESCRIPTION
re: https://github.com/svix/svix-webhooks/pull/892/files