### PR TITLE
feat(segments): Account for segment anding feature on Rust client

### DIFF
--- a/src/api/rollout.rs
+++ b/src/api/rollout.rs
@@ -161,9 +161,20 @@ pub struct RolloutThreshold {
     pub value: bool,
 }
 
-#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Default, Clone, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RolloutSegment {
-    pub segment_key: String,
+    pub segment_key: Option<String>,
+    pub segment_keys: Option<Vec<String>>,
+    pub segment_operator: Option<SegmentOperator>,
     pub value: bool,
+}
+
+#[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq)]
+pub enum SegmentOperator {
+    #[default]
+    #[serde(rename = "OR_SEGMENT_OPERATOR")]
+    Or,
+    #[serde(rename = "AND_SEGMENT_OPERATOR")]
+    And,
 }

--- a/src/api/rule.rs
+++ b/src/api/rule.rs
@@ -90,8 +90,19 @@ pub struct RuleCreateRequest {
     pub namespace_key: Option<String>,
     #[serde(skip_serializing)]
     pub flag_key: String,
-    pub segment_key: String,
+    pub segment_key: Option<String>,
+    pub segment_keys: Option<Vec<String>>,
+    pub segment_operator: Option<SegmentOperator>,
     pub rank: usize,
+}
+
+#[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq)]
+pub enum SegmentOperator {
+    #[default]
+    #[serde(rename = "OR_SEGMENT_OPERATOR")]
+    Or,
+    #[serde(rename = "AND_SEGMENT_OPERATOR")]
+    And,
 }
 
 #[derive(Debug, Default, Serialize)]
@@ -103,7 +114,9 @@ pub struct RuleUpdateRequest {
     pub flag_key: String,
     #[serde(skip_serializing)]
     pub id: String,
-    pub segment_key: String,
+    pub segment_key: Option<String>,
+    pub segment_keys: Option<Vec<String>>,
+    pub segment_operator: Option<SegmentOperator>,
     pub rank: u32,
 }
 
@@ -158,7 +171,9 @@ pub struct Rule {
     pub id: String,
     pub rank: u32,
     pub distributions: Vec<Distribution>,
-    pub segment_key: String,
+    pub segment_key: Option<String>,
+    pub segment_keys: Option<Vec<String>>,
+    pub segment_operator: Option<SegmentOperator>,
     pub flag_key: String,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -172,8 +172,9 @@ async fn integration_api() {
                 flag_key: flag_key.into(),
                 rank: 2,
                 segment: Some(RolloutSegment {
-                    segment_key: segment_key.into(),
+                    segment_key: Some(segment_key.into()),
                     value: true,
+                    ..Default::default()
                 }),
                 ..Default::default()
             })
@@ -274,7 +275,7 @@ async fn integration_api() {
             .create(&RuleCreateRequest {
                 rank: 1,
                 flag_key: flag_key.into(),
-                segment_key: segment_key.into(),
+                segment_key: Some(segment_key.into()),
                 ..Default::default()
             })
             .await
@@ -283,7 +284,7 @@ async fn integration_api() {
         assert!(rule.id.len() != 0);
         assert_eq!(rule.flag_key, flag_key);
         assert_eq!(rule.rank, 1u32);
-        assert_eq!(rule.segment_key, "segment-a");
+        assert_eq!(rule.segment_key, Some("segment-a".into()));
         assert_eq!(rule.distributions, (&[]).to_vec());
 
         rule


### PR DESCRIPTION
Account for new Segment and'ing feature on Rust client.
- Adds new fields for `RuleCreateRequest`, `RuleUpdateRequest`, and `RolloutCreateRequest` under `RolloutSegment`
- Accounts for those changes in the integration test suite

Completes FLI-550