### PR TITLE
feat: add flag_key to VariantEvaluationResponse and BooleanEvaluationResponse

### DIFF
--- a/src/evaluation/mod.rs
+++ b/src/evaluation/mod.rs
@@ -53,6 +53,7 @@ pub struct BooleanEvaluation {
     pub request_id: String,
     pub request_duration_millis: f64,
     pub timestamp: DateTime<Utc>,
+    pub flag_key: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize)]
@@ -67,6 +68,7 @@ pub struct VariantEvaluation {
     pub request_id: String,
     pub request_duration_millis: f64,
     pub timestamp: DateTime<Utc>,
+    pub flag_key: String,
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -345,6 +345,7 @@ async fn integration_api() {
 
         assert_eq!(boolean_evaluation.enabled, true);
         assert_eq!(boolean_evaluation.reason, V2Reason::Default);
+        assert_eq!(boolean_evaluation.flag_key, flag_key);
     }
 
     async fn variant_evaluate(client: &EvaluationClient<'_>, flag_key: &str) {
@@ -367,6 +368,7 @@ async fn integration_api() {
         assert_eq!(variant_evaluation.segment_keys[0], "segment-a");
         assert_eq!(variant_evaluation.variant_key, "variant-a");
         assert_eq!(variant_evaluation.variant_attachment, "");
+        assert_eq!(variant_evaluation.flag_key, flag_key);
     }
 
     async fn delete_rollout(client: &ApiClient, flag_key: &str, id: &str) {


### PR DESCRIPTION
Add `flag_key` to Variant and Boolean Evaluation responses.