### PR TITLE
feat: add namespace scope for creation of tokens

### DIFF
--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -9,6 +9,7 @@ use url::Url;
 
 pub const METADATA_LABEL_NAME: &str = "io.flipt.auth.token.name";
 pub const METADATA_LABEL_DESCRIPTION: &str = "io.flipt.auth.token.description";
+pub const METADATA_LABEL_NAMESPACE: &str = "io.flipt.auth.token.namespace";
 
 const DEFAULT_LIMIT: usize = 100;
 

--- a/src/auth/token.rs
+++ b/src/auth/token.rs
@@ -40,6 +40,7 @@ pub struct TokenCreateRequest {
     pub name: String,
     pub description: String,
     pub expires_at: Option<DateTime<Utc>>,
+    pub namespace_key: String,
 }
 
 impl Default for TokenCreateRequest {
@@ -48,6 +49,7 @@ impl Default for TokenCreateRequest {
             name: "".into(),
             description: "".into(),
             expires_at: None,
+            namespace_key: "".into(),
         }
     }
 }

--- a/src/auth/token.rs
+++ b/src/auth/token.rs
@@ -40,7 +40,7 @@ pub struct TokenCreateRequest {
     pub name: String,
     pub description: String,
     pub expires_at: Option<DateTime<Utc>>,
-    pub namespace_key: String,
+    pub namespace_key: Option<String>,
 }
 
 impl Default for TokenCreateRequest {
@@ -49,7 +49,7 @@ impl Default for TokenCreateRequest {
             name: "".into(),
             description: "".into(),
             expires_at: None,
-            namespace_key: "".into(),
+            namespace_key: None,
         }
     }
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -437,7 +437,7 @@ async fn integration_auth() {
         .create(&TokenCreateRequest {
             name: "e2e".into(),
             description: "foobar".into(),
-            namespace_key: "default".into(),
+            namespace_key: Some("default".into()),
             ..Default::default()
         })
         .await


### PR DESCRIPTION
This PR adds the bit of functionality to scope a namespace token when necessary, adding a `namespace_key` to the `TokenCreateRequest`.